### PR TITLE
added .clangd/ to .gitignore

### DIFF
--- a/dotfiles/.gitignore
+++ b/dotfiles/.gitignore
@@ -550,3 +550,5 @@ healthchecksdb
 MigrationBackup/
 
 # End of https://www.gitignore.io/api/c,git,c++,gcov,cmake,ninja,valgrind,qtcreator,sonarqube,visualstudio,visualstudiocode
+
+.clangd/


### PR DESCRIPTION
Clangd generates a directory containing some hashes inside base directory of the project. This content is not intended to be versioned.