### PR TITLE
Implementation of auto-install generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
         - [SOURCES (optional)](#sources-optional)
         - [HEADERS (optional)](#headers-optional)
         - [WITH_COVERAGE (optional)](#with_coverage-optional)
+        - [WITH_INSTALL (optional)](#with_install-optional)
         - [COVERAGE_TARGETS (optional)](#coverage_targets-optional)
         - [COVERAGE_LCOV_FILTER_PATTERN (optional)](#coverage_lcov_filter_pattern-optional)
         - [COVERAGE_GCOVR_FILTER_PATTERN (optional)](#coverage_gcovr_filter_pattern-optional)
@@ -732,6 +733,7 @@ The created target's compilation unit will be automatically gathered using AutoC
                 [SOURCES [<source_path> ...]]
                 [HEADERS [<header_path> ...]]
                 [WITH_COVERAGE]
+                [WITH_INSTALL]
                 [COVERAGE_TARGETS [<target_name> ...]]
                 [COVERAGE_LCOV_FILTER_PATTERN <lcov-pattern>]
                 [COVERAGE_GCOVR_FILTER_PATTERN <gcovr-pattern>]
@@ -1108,6 +1110,27 @@ Example:
         WITH_COVERAGE
         # Disable auto source/header file gathering for this target
         NO_AUTO_COMPILATION_UNIT
+    )
+```
+
+##### WITH_INSTALL (optional)
+
+Automatically generate install step for the target.
+
+Example:
+
+```cmake
+    project(proj VERSION 0.1.0 LANGUAGES CXX)
+
+    # Create a static library target with the name of
+    # `project.component-x`
+    make_target(
+        # Create an unit test target
+        TYPE STATIC
+        # Append `.component-x` suffix to the created target
+        SUFFIX .component-x
+        # Create installation step for project
+        WITH_INSTALL
     )
 ```
 

--- a/cmake/modules/helper/AutoTarget.cmake
+++ b/cmake/modules/helper/AutoTarget.cmake
@@ -182,7 +182,7 @@ function(make_install)
     endif()
 
     install (
-        TARGETS ${ARGS_TARGET}
+        TARGETS ${ARGS_TARGET_NAME}
         ARCHIVE 
             DESTINATION lib
         LIBRARY 

--- a/cmake/modules/helper/AutoTarget.cmake
+++ b/cmake/modules/helper/AutoTarget.cmake
@@ -161,11 +161,53 @@ function(setup_coverage_targets)
     endif()
 endfunction()
 
+
+function(make_install)
+    
+    cmake_parse_arguments(ARGS "" "TARGET_NAME;TYPE;" "" ${ARGN})
+
+    if(NOT DEFINED ARGS_TARGET_NAME)
+        message(FATAL_ERROR "make_install() requires TARGET_NAME parameter.")
+    endif()
+
+    if(NOT DEFINED ARGS_TYPE)
+        message(FATAL_ERROR "make_install() requires TYPE parameter.")
+    endif()
+
+    if(${ARGS_TYPE} STREQUAL "UNIT_TEST")
+        return()
+    endif()
+    if(${ARGS_TYPE} STREQUAL "BENCHMARK")
+        return()
+    endif()
+
+    install (
+        TARGETS ${ARGS_TARGET}
+        ARCHIVE 
+            DESTINATION lib
+        LIBRARY 
+            DESTINATION lib
+        RUNTIME 
+            DESTINATION bin
+        PUBLIC_HEADER
+            DESTINATION include
+        PRIVATE_HEADER
+            DESTINATION include
+    )
+
+    install (
+        DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+        DESTINATION include
+        FILES_MATCHING PATTERN "**/*.*"
+    )
+
+endfunction()
+
 # This is a function which is created with aim of
 # removing code repetition in cmake files.
 # We're doing pretty much the same stuff on all of our library targets.
 function(make_target)
-    cmake_parse_arguments(ARGS "WITH_COVERAGE;EXPOSE_PROJECT_METADATA;NO_AUTO_COMPILATION_UNIT;" "TYPE;SUFFIX;PREFIX;NAME;PARTOF;PROJECT_METADATA_PREFIX;WORKING_DIRECTORY;" "LINK;COMPILE_OPTIONS;COMPILE_DEFINITIONS;DEPENDS;INCLUDES;SOURCES;HEADERS;SYMBOL_VISIBILITY;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;" ${ARGN})
+    cmake_parse_arguments(ARGS "WITH_COVERAGE;WITH_INSTALL;EXPOSE_PROJECT_METADATA;NO_AUTO_COMPILATION_UNIT;" "TYPE;SUFFIX;PREFIX;NAME;PARTOF;PROJECT_METADATA_PREFIX;WORKING_DIRECTORY;" "LINK;COMPILE_OPTIONS;COMPILE_DEFINITIONS;DEPENDS;INCLUDES;SOURCES;HEADERS;SYMBOL_VISIBILITY;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;" ${ARGN})
 
     if(NOT DEFINED ARGS_TYPE)
         message(FATAL_ERROR "make_target() requires TYPE parameter.")
@@ -228,6 +270,14 @@ function(make_target)
             COVERAGE_TARGETS ${ARGS_COVERAGE_TARGETS} 
             COVERAGE_LCOV_FILTER_PATTERN ${ARGS_COVERAGE_LCOV_FILTER_PATTERN} 
             COVERAGE_GCOVR_FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN}
+        )
+    endif()
+
+    # Add install
+    if(ARGS_WITH_INSTALL)
+        make_install(
+            TARGET_NAME ${TARGET_NAME} 
+            TYPE ${ARGS_TYPE} 
         )
     endif()
 

--- a/cmake/modules/helper/AutoTarget.cmake
+++ b/cmake/modules/helper/AutoTarget.cmake
@@ -174,13 +174,6 @@ function(make_install)
         message(FATAL_ERROR "make_install() requires TYPE parameter.")
     endif()
 
-    if(${ARGS_TYPE} STREQUAL "UNIT_TEST")
-        return()
-    endif()
-    if(${ARGS_TYPE} STREQUAL "BENCHMARK")
-        return()
-    endif()
-
     install (
         TARGETS ${ARGS_TARGET_NAME}
         ARCHIVE 


### PR DESCRIPTION
Added WITH_INSTALL argument to make_target function to automatically create a cmake `install()` for the target. Also make_install function is now available to invoke independently.