### PR TITLE
Feature/code coverage

### DIFF
--- a/cmake/modules/helper/AutoTarget.cmake
+++ b/cmake/modules/helper/AutoTarget.cmake
@@ -358,11 +358,12 @@ function(make_target)
     # post options
     if(${ARGS_TYPE} STREQUAL "UNIT_TEST")
         add_test(
-            NAME ${TARGET_NAME} 
+            NAME ${TARGET_NAME}
             COMMAND ${TARGET_NAME} ${ARGS_ARGUMENTS} 
+            # # COMMAND 
             WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY}
         )
-        gtest_discover_tests(${TARGET_NAME})
+        gtest_discover_tests(${TARGET_NAME} WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY})
     endif()
 
 endfunction()

--- a/cmake/modules/helper/AutoTarget.cmake
+++ b/cmake/modules/helper/AutoTarget.cmake
@@ -110,7 +110,7 @@ function(add_target_options)
 endfunction()
 
 function(setup_coverage_targets)
-    cmake_parse_arguments(ARGS "" "TARGET_NAME;TYPE;" "LINK;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;" ${ARGN})
+    cmake_parse_arguments(ARGS "" "TARGET_NAME;TYPE;" "LINK;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;COVERAGE_REPORT_OUTPUT_DIRECTORY;WORKING_DIRECTORY;" ${ARGN})
     if(NOT DEFINED ARGS_TARGET_NAME)
         message(FATAL_ERROR "setup_coverage_targets() requires TARGET_NAME parameter.")
     endif()
@@ -129,6 +129,7 @@ function(setup_coverage_targets)
         set(ARGS_COVERAGE_GCOVR_FILTER_PATTERN "${CMAKE_SOURCE_DIR}")
     endif()
 
+
     if(NOT ${ARGS_TYPE} STREQUAL "INTERFACE")
         if(${PB_PARENT_PROJECT_NAME_UPPER}_TOOLCONF_USE_GCOV AND GCOV)
             target_compile_options(${TARGET_NAME} PRIVATE -fprofile-arcs -ftest-coverage)
@@ -146,13 +147,60 @@ function(setup_coverage_targets)
             endif()
             
             if(${PB_PARENT_PROJECT_NAME_UPPER}_TOOLCONF_USE_GCOVR AND GCOVR)
-                SETUP_TARGET_FOR_COVERAGE_GCOVR_XML(NAME ${TARGET_NAME}.gcovr.xml EXECUTABLE ${TARGET_NAME} DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN})
-                SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML(NAME ${TARGET_NAME}.gcovr.html EXECUTABLE ${TARGET_NAME} DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN})
+
+                SETUP_TARGET_FOR_COVERAGE_GCOVR_XML(
+                    NAME ${TARGET_NAME}.gcovr.xml 
+                    EXECUTABLE ${TARGET_NAME} 
+                    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ 
+                    FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN}
+                    OUTPUT_DIRECTORY ${ARGS_COVERAGE_REPORT_OUTPUT_DIRECTORY}
+                    WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY}
+                )
+
+                SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML(
+                    NAME ${TARGET_NAME}.gcovr.html 
+                    EXECUTABLE ${TARGET_NAME} 
+                    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ 
+                    FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN}
+                    OUTPUT_DIRECTORY ${ARGS_COVERAGE_REPORT_OUTPUT_DIRECTORY}
+                    WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY}
+                )
+
+                # Project-level meta gcovr.xml target
+                if (TARGET ${PB_PARENT_PROJECT_NAME}.gcovr.xml)
+                    add_dependencies(${PB_PARENT_PROJECT_NAME}.gcovr.xml ${TARGET_NAME}.gcovr.xml)
+                else()
+                    add_custom_target(${PB_PARENT_PROJECT_NAME}.gcovr.xml DEPENDS ${TARGET_NAME}.gcovr.xml)
+                endif()
+
+                # Project-level meta gcovr.html target
+                if (TARGET ${PB_PARENT_PROJECT_NAME}.gcovr.html)
+                    add_dependencies(${PB_PARENT_PROJECT_NAME}.gcovr.html ${TARGET_NAME}.gcovr.html)
+                else()
+                    add_custom_target(${PB_PARENT_PROJECT_NAME}.gcovr.html DEPENDS ${TARGET_NAME}.gcovr.html)
+                endif()
+
             endif()
 
             if(${PB_PARENT_PROJECT_NAME_UPPER}_TOOLCONF_USE_LCOV AND LCOV)
-                # dummy.component-x
-                SETUP_TARGET_FOR_COVERAGE_LCOV(NAME ${TARGET_NAME}.lcov EXECUTABLE ${TARGET_NAME} DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ FILTER_PATTERN ${ARGS_COVERAGE_LCOV_FILTER_PATTERN} LCOV_ARGS --directory ${CMAKE_SOURCE_DIR} --no-external)
+
+                SETUP_TARGET_FOR_COVERAGE_LCOV(
+                    NAME ${TARGET_NAME}.lcov 
+                    EXECUTABLE ${TARGET_NAME} 
+                    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ 
+                    FILTER_PATTERN ${ARGS_COVERAGE_LCOV_FILTER_PATTERN} 
+                    LCOV_ARGS --directory ${CMAKE_SOURCE_DIR} --no-external
+                    OUTPUT_DIRECTORY ${ARGS_COVERAGE_REPORT_OUTPUT_DIRECTORY}
+                    WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY}
+                )
+
+                # Project-level meta lcov target
+                if (TARGET ${PB_PARENT_PROJECT_NAME}.lcov)
+                    add_dependencies(${PB_PARENT_PROJECT_NAME}.lcov ${TARGET_NAME}.lcov)
+                else()
+                    add_custom_target(${PB_PARENT_PROJECT_NAME}.lcov DEPENDS ${TARGET_NAME}.lcov)
+                endif()
+
             endif()
 
         endif() 
@@ -200,7 +248,7 @@ endfunction()
 # removing code repetition in cmake files.
 # We're doing pretty much the same stuff on all of our library targets.
 function(make_target)
-    cmake_parse_arguments(ARGS "WITH_COVERAGE;WITH_INSTALL;EXPOSE_PROJECT_METADATA;NO_AUTO_COMPILATION_UNIT;" "TYPE;SUFFIX;PREFIX;NAME;OUTPUT_NAME;PARTOF;PROJECT_METADATA_PREFIX;WORKING_DIRECTORY;" "LINK;COMPILE_OPTIONS;COMPILE_DEFINITIONS;DEPENDS;INCLUDES;SOURCES;HEADERS;SYMBOL_VISIBILITY;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;ARGUMENTS;" ${ARGN})
+    cmake_parse_arguments(ARGS "WITH_COVERAGE;WITH_INSTALL;EXPOSE_PROJECT_METADATA;NO_AUTO_COMPILATION_UNIT;" "TYPE;SUFFIX;PREFIX;NAME;OUTPUT_NAME;PARTOF;PROJECT_METADATA_PREFIX;WORKING_DIRECTORY;COVERAGE_REPORT_OUTPUT_DIRECTORY;" "LINK;COMPILE_OPTIONS;COMPILE_DEFINITIONS;DEPENDS;INCLUDES;SOURCES;HEADERS;SYMBOL_VISIBILITY;COVERAGE_TARGETS;COVERAGE_LCOV_FILTER_PATTERN;COVERAGE_GCOVR_FILTER_PATTERN;ARGUMENTS;" ${ARGN})
 
     if(NOT DEFINED ARGS_TYPE)
         message(FATAL_ERROR "make_target() requires TYPE parameter.")
@@ -262,6 +310,8 @@ function(make_target)
             COVERAGE_TARGETS ${ARGS_COVERAGE_TARGETS} 
             COVERAGE_LCOV_FILTER_PATTERN ${ARGS_COVERAGE_LCOV_FILTER_PATTERN} 
             COVERAGE_GCOVR_FILTER_PATTERN ${ARGS_COVERAGE_GCOVR_FILTER_PATTERN}
+            COVERAGE_REPORT_OUTPUT_DIRECTORY ${ARGS_COVERAGE_REPORT_OUTPUT_DIRECTORY}
+            WORKING_DIRECTORY ${ARGS_WORKING_DIRECTORY}
         )
     endif()
 

--- a/script/common.sh
+++ b/script/common.sh
@@ -45,8 +45,8 @@ hadouken.get_top_level_project_name(){
     # Common headers
     hadouken.define_relative_paths $1 LRP
 
-    if test -f "${LRP["PROJECT"]}/CMakeLists.txt"; then
-        hadouken_top_level_project_name=$(cat ${LRP["PROJECT"]}/CMakeLists.txt | grep -o -P "project\((.*)\)" | sed -e 's/project(//g' | sed 's/.$//')
+    if test -f "${LRP["BUILD"]}/CMakeCache.txt"; then
+        hadouken_top_level_project_name=$(grep CMAKE_PROJECT_NAME ${LRP["BUILD"]}/CMakeCache.txt | cut -d'=' -f2)
     else
         return 1
     fi    

--- a/script/hadouken.sh
+++ b/script/hadouken.sh
@@ -108,6 +108,9 @@ case $1 in
     -t|--test)
       ${RP["SCRIPT"]}/project-test.sh ${@:2}
     ;;
+    -cv|--coverage)
+      ${RP["SCRIPT"]}/project-coverage.sh ${@:2}
+    ;;
     -d|--documentation)
       ${RP["SCRIPT"]}/project-generate-documentation.sh ${@:2}
     ;;
@@ -131,37 +134,54 @@ case $1 in
       echo -e ""
       echo "Use one of the following combos:"
       echo -e "Project:"
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-b|--build\tbuild project"
       echo -e "\t\t| build previously configured project. Any extra arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --build\`\t\t# build via CMake."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-x|--clean\tclean project"
       echo -e "\t\t| remove PROJECT_ROOT/build directory."
       echo -e "\t\t| example: \`hadouken --clean\`\t\t# removes PROJECT_ROOT/build directory."
       echo -e "\t\t| example: \`hadouken --clean --deep\`\t# runs git clean -fxd on project root."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-c|--configure"
       echo -e "\t\t| configure project located in PROJECT_ROOT to PROJECT_ROOT/build directory with cmake"
       echo -e "\t\t| any following arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --configure --target=Debug\`"
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-i|--install\tinstall project"
       echo -e "\t\t| install previosuly built project. Any extra arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --install\`\t\t# install via CMake."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-p|--pack\tpack project (using cpack)"
       echo -e "\t\t| package previously build project. Any extra arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --pack\`\t\t# pack via CMake."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-t|--test\trun unit tests for project (using ctest)"
       echo -e "\t\t| run unit tests of previously build project. Any extra arguments will be forwarded to CTest."
-      echo -e "\t\t| example: \`hadouken --test\`\t\t# pack via CMake."
+      echo -e "\t\t| example: \`hadouken --test\`\t\t# test via CTest."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
+      echo -e "\t-cv|--coverage\trun code coverage for project"
+      echo -e "\t\t| run code coverage targets of previously build project."
+      echo -e "\t\t| example: \`hadouken --coverage --html\`\t\t# run all code coverage targets, generate HTML reports"
+      echo -e "\t\t| example: \`hadouken --coverage --xml\`\t# run all code coverage targets, generate XML reports in cobertura format."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-f|--format\trun all clang-format targets for the project."
       echo -e "\t\t| run all format targets defined for the project. Any extra arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --format\`\t\t# call project.format target via CMake."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-ti|--tidy\trun all clang-tidy targets for the project."
       echo -e "\t\t| run all tidy targets defined for the project. Any extra arguments will be forwarded to CMake."
       echo -e "\t\t| example: \`hadouken --tidy\`\t\t# call project.tidy target via CMake."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-a|--all\tclean->configure->build->pack project"
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "Hadouken:"
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       echo -e "\t-u|--upgrade\tupgrade hadouken to latest release"
       echo -e "\t\t| this basically runs submodule update, reduced to a command for ease of use."
       echo -e "\t\t| example: \`hadouken --upgrade\`\t\t# upgrade hadouken to latest master release."
+      echo -e "\t- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
       exit 1
     ;;
 esac

--- a/script/project-coverage.sh
+++ b/script/project-coverage.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# ______________________________________________________
+# Hadouken project test script.
+#
+# @file 	project-test.sh
+# @author   Mustafa Kemal GILOR <mgilor@nettsi.com>
+# @date 	10.05.2020
+# 
+# Copyright (c) Nettsi Informatics Technology Inc. 
+# All rights reserved. Licensed under the Apache 2.0 License. 
+# See LICENSE in the project root for license information.
+# 
+# SPDX-License-Identifier:	Apache 2.0
+# ______________________________________________________
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+SCRIPT_ROOT="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+# Relative paths
+declare -A RP
+# Common headers
+source $SCRIPT_ROOT/common.sh && hadouken.define_relative_paths $SCRIPT_ROOT RP
+
+if hadouken.get_top_level_project_name $SCRIPT_ROOT; then
+  if [ "$#" -ge 1 ]; then
+    case $1 in
+      -gx|--gcov-xml)
+        shift
+        cmake --build ${RP["BUILD"]} ${@:1} --target $hadouken_top_level_project_name.gcovr.xml -- -j $(nproc)
+      ;;
+      -gh|--gcov-html)
+        shift
+        cmake --build ${RP["BUILD"]} ${@:1} --target $hadouken_top_level_project_name.gcovr.html -- -j $(nproc)
+      ;;
+      -l|--lcov)
+        shift
+        cmake --build ${RP["BUILD"]} ${@:1} --target $hadouken_top_level_project_name.lcov -- -j $(nproc)
+      ;;
+      *)
+        echo "Unrecognized argument. Valid arguments are: "
+        echo "-gx | --gcov-xml"
+        echo "-gh | --gcov-html"
+        echo "-l | --lcov"
+        exit 1
+      ;;
+    esac
+  else
+      echo "You need to provide desired report output format (xml or html)."
+  fi
+else
+    echo "Could not determine top level project name."
+fi


### PR DESCRIPTION
Implemented `./hadouken --coverage` command. …

Fixes:
- Fixed unit test working directory issue

Enhancements:
- Coverage targets now supports output directory specification
- Coverage targets now respect specified working directory for unit test
- Found more reliable way to retrieve CMake project name