### PR TITLE
disable auto compilation unit for auto-targets:

### DIFF
--- a/cmake/modules/toolconf/GoogleBenchmark.cmake
+++ b/cmake/modules/toolconf/GoogleBenchmark.cmake
@@ -43,6 +43,7 @@ if(${HDK_ROOT_PROJECT_NAME_UPPER}_TOOLCONF_USE_GOOGLE_BENCH)
         NAME ${HDK_ROOT_PROJECT_NAME}.hadouken_autotargets.benchmark    
         TYPE STATIC SOURCES ${HDK_ROOT_PROJECT_SOURCE_DIR}/.hadouken/cmake/modules/toolconf/GoogleBenchmark.cpp 
         LINK PUBLIC benchmark::benchmark
+        NO_AUTO_COMPILATION_UNIT
     )
     hdk_log_debug("Auto-created `${HDK_ROOT_PROJECT_NAME}.hadouken_autotargets.benchmark` target")
 

--- a/cmake/modules/toolconf/GoogleTest.cmake
+++ b/cmake/modules/toolconf/GoogleTest.cmake
@@ -44,6 +44,7 @@ if(${HDK_ROOT_PROJECT_NAME_UPPER}_TOOLCONF_USE_GOOGLE_TEST)
         NAME ${HDK_ROOT_PROJECT_NAME}.hadouken_autotargets.test 
         TYPE STATIC SOURCES ${HDK_ROOT_PROJECT_SOURCE_DIR}/.hadouken/cmake/modules/toolconf/GoogleTest.cpp 
         LINK PUBLIC GTest::GTest
+        NO_AUTO_COMPILATION_UNIT
     )
     hdk_log_debug("Auto-created `${HDK_ROOT_PROJECT_NAME}.hadouken_autotargets.test` target")
     hdk_log_unindent(1)


### PR DESCRIPTION
- disabled auto compilation unit for GoogleTest auto-target
- disabled auto compilation unit for GoogleBench auto-target

These targets were picking up root directory src/ and include/ folder, which is unintended. This patch fixes that.